### PR TITLE
test the usage of the same buffer for second time

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -74,3 +74,8 @@ issues:
   exclude-use-default: false
   exclude:
     - should have a package comment
+  exclude-rules:
+    - linters:
+        - gosec
+      path: pool_test\.go
+      text: "G103: Use of unsafe calls should be audited"

--- a/README.md
+++ b/README.md
@@ -9,6 +9,10 @@ The library was created to avoid repeating this code.
 
 Here is a good article how to implement and properly use the Buffer Pools: https://www.captaincodeman.com/2017/06/02/golang-buffer-pool-gotcha
 
+Check the [tests](pool_test.go) file for some examples.
+
+PS: The package is stable and the new releases are not expected. 
+
 ## Usage
 
 ```go
@@ -35,6 +39,7 @@ func render(tmpl string, data interface{}) (string, error) {
 		return "", err
 	}
 
+	// the usage of buf.String is safe 
 	return buf.String(), nil
 }
 

--- a/pool.go
+++ b/pool.go
@@ -25,7 +25,7 @@ type pool struct {
 func New() Pool {
 	p := pool{
 		pool: sync.Pool{
-			New: func() interface{} {
+			New: func() any {
 				return new(bytes.Buffer)
 			},
 		},

--- a/pool_test.go
+++ b/pool_test.go
@@ -1,7 +1,9 @@
 package bufferspool_test
 
 import (
+	"io"
 	"testing"
+	"unsafe"
 
 	"github.com/stretchr/testify/require"
 
@@ -11,7 +13,7 @@ import (
 func TestGlobalPool(t *testing.T) {
 	b1 := bufferspool.Get()
 	b2 := bufferspool.Get()
-	require.NotSame(t, b1, b2)
+	require.NotEqual(t, unsafe.Pointer(b1), unsafe.Pointer(b2))
 
 	b1.WriteString("foo")
 	bufferspool.Put(b1)
@@ -23,10 +25,52 @@ func TestCustomPool(t *testing.T) {
 	p := bufferspool.New()
 	b1 := p.Get()
 	b2 := p.Get()
-	require.NotSame(t, b1, b2)
+	require.NotEqual(t, unsafe.Pointer(b1), unsafe.Pointer(b2))
 
 	b1.WriteString("foo")
 	p.Put(b1)
 	b2 = p.Get()
 	require.Zero(t, b2.Len())
+}
+
+func TestSafety(t *testing.T) {
+	p := bufferspool.New()
+	b1 := p.Get()
+	b1.WriteString("foo42")
+	b1AsString := b1.String()
+	b1AsBytes := b1.Bytes()
+	b1Data, err := io.ReadAll(b1)
+	require.NoError(t, err)
+
+	require.Equal(t, "foo42", b1AsString)
+	require.Equal(t, []byte("foo42"), b1AsBytes, string(b1AsBytes))
+	require.Equal(t, []byte("foo42"), b1Data, string(b1Data))
+
+	// put the same buffer to the poll several times to increase the chance that the same object will be returned
+	// this is the only way to test the Pools if we need already used object
+	for i := 0; i < 10; i++ {
+		p.Put(b1)
+	}
+	b2 := p.Get()
+	defer p.Put(b2)
+
+	require.Equal(t, unsafe.Pointer(b1), unsafe.Pointer(b2))
+	require.Empty(t, b2.Bytes())
+
+	b2.WriteString("bar")
+	b2AsString := b2.String()
+	b2AsBytes := b2.Bytes()
+	b2Data, err := io.ReadAll(b2)
+	require.NoError(t, err)
+
+	require.Equal(t, "bar", b2AsString)
+	require.Equal(t, []byte("bar"), b2AsBytes, string(b2AsBytes))
+	require.Equal(t, []byte("bar"), b2Data, string(b2Data))
+
+	// usage of string is safe and should not be changed
+	require.Equal(t, "foo42", b1AsString)
+	// usage of bytes is unsafe, the b1AsBytes must contain `bar42` instead of `foo42` or `bar`
+	require.Equal(t, []byte("bar42"), b1AsBytes, string(b1AsBytes))
+	// usage of Reader is safe and should not be changed
+	require.Equal(t, []byte("foo42"), b1Data, string(b1Data))
 }


### PR DESCRIPTION
Testing that the buffer which previously was used and then returned to the pool is safe:
* the buffer must be empty at the beginning
* after writing new data to the buffer, the all function returns written data
* the data stored in a variable and read by using `.String()` function or using the `io.ReadAll()` during the first usage is unchanged
* the data stored in a variable and read by using `.Bytes()` function during the first usage is changed to new data. Also the old data is bigger than new that leads to the situation when the variable contains a mix of new and old data.