### PR TITLE
chore(deps): group Dependabot updates for better management

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,6 +4,13 @@ updates:
     directory: "/"
     schedule:
       interval: weekly
+    groups:
+      golangci-lint:
+        patterns:
+          - "golangci*"
+      ci:
+        patterns:
+          - "*"
   - package-ecosystem: github-actions
     directory: "/"
     schedule:


### PR DESCRIPTION
Add grouping to Dependabot configuration to separate golangci-lint
updates and other CI-related updates. This improves update clarity and
allows targeted review of dependency changes. Groups include golangci-lint
and ci patterns, scheduled weekly.