### PR TITLE
chore(dependabot): reorder github-actions update config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,6 +4,10 @@ updates:
     directory: "/"
     schedule:
       interval: weekly
+  - package-ecosystem: github-actions
+    directory: "/"
+    schedule:
+      interval: weekly
     groups:
       golangci-lint:
         patterns:
@@ -11,7 +15,3 @@ updates:
       ci:
         patterns:
           - "*"
-  - package-ecosystem: github-actions
-    directory: "/"
-    schedule:
-      interval: weekly


### PR DESCRIPTION
Move the github-actions package-ecosystem update block below the golangci-lint
group to improve readability and maintain consistency in the dependabot.yml
configuration. This change does not affect functionality but organizes the file
for easier maintenance.