### PR TITLE
feat: add Do method to Pool interface for scoped buffer use

### DIFF
--- a/.github/workflows/checks.yaml
+++ b/.github/workflows/checks.yaml
@@ -57,7 +57,6 @@ jobs:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       - uses: actions/setup-go@d35c59abb061a4a6fb18e82ac0862c26744d6ab5 # v5.5.0
         with:
-          check-latest: true
           go-version-file: go.mod
       - uses: golangci/golangci-lint-action@4afd733a84b1f43292c63897423277bb7f4313a9 # v8.0.0
         with:

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/sv-tools/buffers-pool
 
-go 1.22.0
+go 1.22
 
 require github.com/stretchr/testify v1.10.0
 

--- a/pool.go
+++ b/pool.go
@@ -13,8 +13,13 @@ func init() {
 
 // Pool is an interface to work with the Buffers Pool
 type Pool interface {
+	// Get returns a buffer from the pool or creates a new one
 	Get() *bytes.Buffer
+	// Put resets and puts back a given buffer to the pool
 	Put(buf *bytes.Buffer)
+	// Do executes a function with a buffer from the pool.
+	// The buffer will be put back to the pool after the function is executed.
+	Do(f func(b *bytes.Buffer))
 }
 
 type pool struct {
@@ -51,4 +56,16 @@ func Put(buf *bytes.Buffer) {
 func (p *pool) Put(buf *bytes.Buffer) {
 	buf.Reset()
 	p.pool.Put(buf)
+}
+
+// Do executes a function with a buffer from the pool.
+// The buffer will be put back to the pool after the function is executed.
+func Do(f func(b *bytes.Buffer)) {
+	globalPool.Do(f)
+}
+
+func (p *pool) Do(f func(b *bytes.Buffer)) {
+	buf := p.Get()
+	defer p.Put(buf)
+	f(buf)
 }

--- a/pool_test.go
+++ b/pool_test.go
@@ -1,6 +1,7 @@
 package bufferspool_test
 
 import (
+	"bytes"
 	"io"
 	"testing"
 	"unsafe"
@@ -20,6 +21,12 @@ func TestGlobalPool(t *testing.T) {
 	bufferspool.Put(b1)
 	b2 = bufferspool.Get()
 	require.Zero(t, b2.Len())
+
+	bufferspool.Do(func(b *bytes.Buffer) {
+		require.Zero(t, b.Len())
+		b.WriteString("foo")
+		require.Equal(t, "foo", b.String())
+	})
 }
 
 func TestCustomPool(t *testing.T) {
@@ -34,6 +41,12 @@ func TestCustomPool(t *testing.T) {
 	p.Put(b1)
 	b2 = p.Get()
 	require.Zero(t, b2.Len())
+
+	p.Do(func(b *bytes.Buffer) {
+		require.Zero(t, b.Len())
+		b.WriteString("foo")
+		require.Equal(t, "foo", b.String())
+	})
 }
 
 func TestSafety(t *testing.T) {


### PR DESCRIPTION
Introduce a Do method to the Pool interface and its implementation,
allowing users to execute a function with a buffer from the pool.
The buffer is automatically returned to the pool after use,
ensuring safe and convenient buffer management.

Add tests to verify the Do method behavior for both the global pool
and custom pool instances.

Remove unnecessary check-latest flag from GitHub Actions workflow
and update Go version in go.mod to 1.22 without patch version.