### PR TITLE
ci: test use named Go channels and stable runner

### DIFF
--- a/.github/workflows/checks.yaml
+++ b/.github/workflows/checks.yaml
@@ -22,9 +22,9 @@ jobs:
     strategy:
       matrix:
         go:
-          - "1.22"
-          - "1.23"
-          - "1.24"
+          - "1.22" # minimal supported
+          - oldstable
+          - stable
     steps:
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
       - uses: actions/setup-go@d35c59abb061a4a6fb18e82ac0862c26744d6ab5 # v5.5.0
@@ -57,7 +57,7 @@ jobs:
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
       - uses: actions/setup-go@d35c59abb061a4a6fb18e82ac0862c26744d6ab5 # v5.5.0
         with:
-          go-version-file: go.mod
+          go-version: stable
       - uses: golangci/golangci-lint-action@4afd733a84b1f43292c63897423277bb7f4313a9 # v8.0.0
         with:
           version: latest


### PR DESCRIPTION
Update GitHub Actions checks to use named Go channel identifiers and pin
the setup-go action to use a stable Go version for the runner.

- Replace explicit patch versions (1.23, 1.24) with "oldstable" and
  "stable", keeping "1.22" as the documented minimal supported
  version. This simplifies maintenance of the matrix and aligns with
  setup-go channel naming.
- Change the setup-go invocation in the lint job to use go-version
  instead of reading from go.mod, and set it to "stable" so the job
  consistently runs on the current stable Go rather than a file-derived
  version.

These changes improve CI resilience against Go toolchain churn and make
the matrix intent clearer.